### PR TITLE
Allow user to specify arbitrary extra user-data in advanced options.

### DIFF
--- a/biocloudcentral/forms.py
+++ b/biocloudcentral/forms.py
@@ -74,6 +74,12 @@ class CloudManForm(forms.Form):
                               "See <a href='https://bitbucket.org/galaxy/cloudman/wiki/SharedInstances'>"
                               "this page</a> for a list of public shared instances."\
                               .format(ud_url, target))
+    extra_user_data = forms.CharField(required=False,
+                                label="Extra User-Data",
+                                widget=forms.widgets.Textarea(attrs={"class": textbox_size}),
+                                help_text="Pass advanced properties to CloudMan via the the cloud" \
+                                "infrastructure's user-data mechanism. Properties should be in YAML" \
+                                "formatted key-value pairs.")
     image_id = DynamicChoiceField((("", "Choose cloud type first"),),
                             help_text="The machine image to start (* indicates the default machine image).",
                             label="Image ID",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ boto>=2.1.1
 python-memcached>=1.47
 wsgiref==0.1.2
 blend-lib>=0.1
+pyyaml


### PR DESCRIPTION
This pull request is a little more questionable. It might not "fit" with the BioCloudCentral philosophy. So basically I am doing a lot of interesting things with user-data in my customized CloudMan instances - dynamically overriding arbitrary galaxy universe config properties (admin users, auth settings, defining job runners, etc...), disabling block storage, pulling my own CloudMan fork down from bitbucket, etc...

It probably doesn't make sense to try to define form elements for each of these options or that advanced form would become ludicrous, so this changeset allows the user to define arbitrary user-data to pass along to CloudMan. I think it could be useful, but I would definitely understand a desire to optimize BioCloudCentral for more traditional setups - so feel completely free to reject this pull request.
