### PR TITLE
added id of custom ami with JCVI's pipelines

### DIFF
--- a/biocloudcentral/aws_db_data.json
+++ b/biocloudcentral/aws_db_data.json
@@ -180,5 +180,18 @@
       "description": "Galaxy CloudMan on Ubuntu 10.04: 22 March 2011",
       "cloud": 1
     }
-  }
+  },
+  {
+    "pk": 13, 
+    "model": "biocloudcentral.image", 
+    "fields": {
+      "updated": "2013-08-01", 
+      "added": "2013-08-01", 
+      "kernel_id": "", 
+      "default": false, 
+      "ramdisk_id": "", 
+      "image_id": "ami-a987f6c0",
+      "description": "JCVI Viral and Prokaryotic Pipelines",
+      "cloud": 1
+    }
 ]


### PR DESCRIPTION
Adds a custom AMI id that contains JCVI's viral and prokaryotic pipelines.
