### PR TITLE
tweaks to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ under your own account. Once setup, automatically [push to Heroku for live deplo
         $ sudo service bcc start
         $ sudo service bcc_celery start
 
+- Connect to the service at http://your.ip.addr.here/launch
+
+      
+
 [1]: https://www.djangoproject.com/
 [2]: http://usecloudman.org/
 [3]: http://cloudbiolinux.org/


### PR DESCRIPTION
added a line answering a question I had (and guessed at, apparently correctly) when configuring things.
Also, service was unable to start on my ubuntu 12.04 system, and my limited testing seems to indicate that it was because the scriptcalled by the upstart script needed to be executable for upstart to actually spawn it successfully.

Feel free to torpedo this request if I'm off base.
