### PR TITLE
Switch to password form for Secret Keys

### DIFF
--- a/biocloudcentral/forms.py
+++ b/biocloudcentral/forms.py
@@ -46,7 +46,7 @@ class CloudManForm(forms.Form):
         .format(key_url, target))
     secret_key = forms.CharField(
         required=True,
-        widget=forms.TextInput(attrs={"class": "%s disableable" % textbox_size}),
+        widget=forms.PasswordInput(attrs={"class": "%s disableable" % textbox_size}),
         help_text="Your cloud account secret key. For the Amazon cloud, also "
         "available from the <a href='{0}' {1} tabindex='-1'>security credentials page</a>."
         .format(key_url, target))


### PR DESCRIPTION
People keep using CloudLaunch in live demos, and pasting in keys. We can *assume* that they're temporary keys and they're revoking them the second the demo is over, but that's not a safe assumption.

This is likely to be an even worse problem if CloudLaunch training is ever given, as new users may not have properly configured IAM, and a malicious actor could use take advantage of their lack of knowledge of best practices.

xref https://twitter.com/Eric_Rasche/status/618775690343763968