### PR TITLE
Updates required version of six so range imports properly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ python-memcached==1.48
 pytz==2013b
 requests==1.2.3
 simplejson==3.3.0
-six==1.3.0
+six==1.9.0
 wsgiref==0.1.2


### PR DESCRIPTION
I attempted to run the server with `$ honcho -f ProcfileHoncho start` but there was an error with six `08:45:21 celery.1 |  from six.moves import range'
'08:45:21 celery.1 | ImportError: cannot import name range`

Updating six to v1.9.0 fixed this.