### PR TITLE
Bump required bioblend 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ South==0.7.3
 amqp==1.0.12
 anyjson==0.3.3
 billiard==2.7.3.31
-bioblend>=0.6.1
+bioblend>=0.7.0
 boto==2.38.0
 celery==3.0.21
 dj-database-url==0.2.1


### PR DESCRIPTION
... version since this relies on changes from https://github.com/galaxyproject/bioblend/commit/76de5d2e3b9a9035ae8f64e07c738f8a34be95be

That version has not been published yet, but it doesn't change the fact that this rev doesn't work without it.