### PR TITLE
Decouple plugins from the framework

### DIFF
--- a/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
@@ -26,9 +26,9 @@ class AppPlugin():
         @type  name: ``str``
         @param name: Name for this deployment.
 
-        @type  cloud_config: :class:`.cloudlaunch.models.ApplicationVersionCloudConfig`
-        @param cloud_config: A Django model containing infrastructure
-                             specific configuration for this app.
+        @type  cloud_config: ``dict``
+        @param cloud_config: A dict containing cloud infrastructure specific
+                             configuration for this app.
 
         @type  app_config: ``dict``
         @param app_config: A dict containing the original, unprocessed version

--- a/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
@@ -79,8 +79,8 @@ class AppPlugin():
         @type  name: ``str``
         @param name: Name of this deployment.
 
-        @type  cloud_config: :class:`.cloudlaunch.models.ApplicationVersionCloudConfig`
-        @param cloud_config: A Django model containing infrastructure specific
+        @type  cloud_config: ``dict``
+        @param cloud_config: A dict containing cloud infrastructure specific
                              configuration for this app.
 
         @type  app_config: ``dict``

--- a/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
@@ -94,7 +94,7 @@ class AppPlugin():
         pass
 
     @abc.abstractmethod
-    def health_check(self, deployment, provider):
+    def health_check(self, provider, deployment):
         """
         Check the health of this app.
 
@@ -102,14 +102,14 @@ class AppPlugin():
         deployment is running. Applications can implement more elaborate
         health checks.
 
+        @type  provider: :class:`CloudBridge.CloudProvider`
+        @param provider: Cloud provider where the supplied deployment was
+                         created.
+
         @type  deployment: ``dict``
         @param deployment: A dictionary describing an instance of the
                            app deployment. The dict must have at least
                            `launch_result` and `launch_status` keys.
-
-        @type  provider: :class:`CloudBridge.CloudProvider`
-        @param provider: Cloud provider where the supplied deployment was
-                         created.
 
         :rtype: ``dict``
         :return: A dictionary with possibly app-specific fields capturing
@@ -121,19 +121,21 @@ class AppPlugin():
         pass
 
     @abc.abstractmethod
-    def restart(self, deployment, credentials):
+    def restart(self, provider, deployment):
         """
         Restart the appliance associated with the supplied deployment.
 
         This can simply restart the virtual machine on which the deployment
         is running or issue an app-specific call to perform the restart.
 
-        @type  deployment: ``ApplicationDeployment``
-        @param deployment: An instance of the app deployment to delete.
+        @type  provider: :class:`CloudBridge.CloudProvider`
+        @param provider: Cloud provider where the supplied deployment was
+                         created.
 
-        @type  credentials: ``dict``
-        @param credentials: Cloud provider credentials to use when deleting
-                            the deployment.
+        @type  deployment: ``dict``
+        @param deployment: A dictionary describing an instance of the
+                           app deployment to be restarted. The dict must have
+                           at least `launch_result` and `launch_status` keys.
 
         :rtype: ``bool``
         :return: The result of restart invocation.
@@ -141,19 +143,21 @@ class AppPlugin():
         pass
 
     @abc.abstractmethod
-    def delete(self, deployment, credentials):
+    def delete(self, provider, deployment):
         """
         Delete resource(s) associated with the supplied deployment.
 
         *Note* that this method will delete resource(s) associated with
-        the deployment - this is un-recoverable action.
+        the deployment - this is an un-recoverable action.
 
-        @type  deployment: ``ApplicationDeployment``
-        @param deployment: An instance of the app deployment to delete.
+        @type  provider: :class:`CloudBridge.CloudProvider`
+        @param provider: Cloud provider where the supplied deployment was
+                         created.
 
-        @type  credentials: ``dict``
-        @param credentials: Cloud provider credentials to use when deleting
-                            the deployment.
+        @type  deployment: ``dict``
+        @param deployment: A dictionary describing an instance of the
+                           app deployment to be deleted. The dict must have at
+                           least `launch_result` and `launch_status` keys.
 
         :rtype: ``bool``
         :return: The result of delete invocation.

--- a/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
@@ -94,7 +94,7 @@ class AppPlugin():
         pass
 
     @abc.abstractmethod
-    def health_check(self, deployment, credentials):
+    def health_check(self, deployment, provider):
         """
         Check the health of this app.
 
@@ -102,13 +102,14 @@ class AppPlugin():
         deployment is running. Applications can implement more elaborate
         health checks.
 
-        @type  deployment: ``ApplicationDeployment``
-        @param deployment: An instance of the app deployment on which health
-                           to check.
+        @type  deployment: ``dict``
+        @param deployment: A dictionary describing an instance of the
+                           app deployment. The dict must have at least
+                           `launch_result` and `launch_status` keys.
 
-        @type  credentials: ``dict``
-        @param credentials: Cloud provider credentials to use when checking
-                            the resource status.
+        @type  provider: :class:`CloudBridge.CloudProvider`
+        @param provider: Cloud provider where the supplied deployment was
+                         created.
 
         :rtype: ``dict``
         :return: A dictionary with possibly app-specific fields capturing

--- a/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
@@ -8,8 +8,7 @@ class AppPlugin():
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractstaticmethod
-    def process_app_config(name, cloud_version_config, credentials,
-                           app_config):
+    def process_app_config(provider, name, cloud_config, app_config):
         """
         Validate and build an internal app config.
 
@@ -20,76 +19,83 @@ class AppPlugin():
         running operations, and is designed to provide quick feedback on
         configuration errors to the client.
 
+        @type  provider: :class:`CloudBridge.CloudProvider`
+        @param provider: Cloud provider where the supplied app is to be
+                         created.
+
         @type  name: ``str``
-        @param name: Name of this deployment
-        
-        @type  version_config: :class:`.cloudlaunch.models.ApplicationVersionCloudConfig`
-        @param version_config: A django model containing infrastructure specific
-               configuration for this app.
-        
-        @type  credentials: ``dict``
-        @param credentials: A dict containing provider specific credentials.
-                
+        @param name: Name for this deployment.
+
+        @type  cloud_config: :class:`.cloudlaunch.models.ApplicationVersionCloudConfig`
+        @param cloud_config: A Django model containing infrastructure
+                             specific configuration for this app.
+
         @type  app_config: ``dict``
         @param app_config: A dict containing the original, unprocessed version
-               of the app config. The app config is a merged dict of database
-               stored settings and user-entered settings.
+                           of the app config. The app config is a merged dict
+                           of database stored settings and user-entered
+                           settings.
 
         :rtype: ``dict``
-        :return: a ``dict` containing the launch configuration
+        :return: A ``dict` containing the launch configuration.
         """
         pass
 
     @abc.abstractstaticmethod
     def sanitise_app_config(app_config):
         """
-        Sanitises values in the app_config and returns it.
+        Sanitise values in the app_config.
 
         The returned representation should have all sensitive data such
         as passwords and keys removed, so that it can be safely logged.
 
         @type  app_config: ``dict``
         @param app_config: A dict containing the original, unprocessed version
-               of the app config. The app config is a merged dict of database
-               stored settings and user-entered settings.
+                           of the app config. The app config is a merged dict
+                           of database stored settings and user-entered
+                           settings.
 
         :rtype: ``dict``
-        :return: a ``dict` containing the launch configuration
+        :return: A ``dict` containing the launch configuration.
         """
         pass
 
     @abc.abstractmethod
-    def launch_app(self, task, name, version_config, credentials, app_config,
+    def launch_app(self, provider, task, name, cloud_config, app_config,
                    user_data):
         """
-        Launch a given application on the target infrastructure. This operation
-        is designed to be a celery task, and thus, can contain long-running
-        operations.
-        
+        Launch a given application on the target infrastructure.
+
+        This operation is designed to be a Celery task, and thus, can contain
+        long-running operations.
+
+        @type  provider: :class:`CloudBridge.CloudProvider`
+        @param provider: Cloud provider where the supplied deployment is to be
+                         created.
+
         @type  task: :class:`.celery.app.task`
-        @param task: celery Task object, which can be used to report progress
-        
+        @param task: Celery Task object, which can be used to report progress.
+
         @type  name: ``str``
-        @param name: Name of this deployment
-        
-        @type  version_config: :class:`.cloudlaunch.models.ApplicationVersionCloudConfig`
-        @param version_config: A django model containing infrastructure specific
-               configuration for this app.
-        
-        @type  credentials: ``dict``
-        @param credentials: A dict containing provider specific credentials.
-                
+        @param name: Name of this deployment.
+
+        @type  cloud_config: :class:`.cloudlaunch.models.ApplicationVersionCloudConfig`
+        @param cloud_config: A Django model containing infrastructure specific
+                             configuration for this app.
+
         @type  app_config: ``dict``
         @param app_config: A dict containing the original, unprocessed version
-               of the app config. The app config is a merged dict of database
-               stored settings and user-entered settings.
-                           
+                           of the app config. The app config is a merged dict
+                           of database stored settings and user-entered
+                           settings.
+
         @type  user_data: ``object``
-        @param user_data: An object returned by the process_app_config() method which
-               contains a validated and processed version of the app_config.
+        @param user_data: An object returned by the ``process_app_config()``
+                          method which contains a validated and processed
+                          version of the ``app_config``.
 
         :rtype: ``dict``
-        :return: a ``dict` containing the results of the launch.
+        :return: Results of the launch process.
         """
         pass
 

--- a/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/app_plugin.py
@@ -73,8 +73,10 @@ class AppPlugin():
         @param provider: Cloud provider where the supplied deployment is to be
                          created.
 
-        @type  task: :class:`.celery.app.task`
-        @param task: Celery Task object, which can be used to report progress.
+        @type  task: :class:`Task`
+        @param task: A Task object, which can be used to report progress. See
+                     ``tasks.Task`` for the interface details and sample
+                     implementation.
 
         @type  name: ``str``
         @param name: Name of this deployment.

--- a/django-cloudlaunch/baselaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/base_vm_app.py
@@ -225,7 +225,7 @@ class BaseVMAppPlugin(AppPlugin):
         cloudlaunch_config = app_config.get("config_cloudlaunch", {})
         custom_image_id = cloudlaunch_config.get("customImageID", None)
         img = provider.compute.images.get(
-            custom_image_id or cloud_config.image.image_id)
+            custom_image_id or cloud_config.get('image_id'))
         task.update_state(state='PROGRESSING',
                           meta={'action': "Retrieving or creating a key pair"})
         kp = self._get_or_create_kp(provider,
@@ -238,7 +238,7 @@ class BaseVMAppPlugin(AppPlugin):
         cb_launch_config = self._get_cb_launch_config(provider, img,
                                                       cloudlaunch_config)
         inst_type = cloudlaunch_config.get(
-            'instanceType', cloud_config.default_instance_type)
+            'instanceType', cloud_config.get('default_instance_type'))
 
         log.debug("Launching with subnet %s and SGs %s" % (subnet_id, sgs))
         log.info("Launching base_vm with UD:\n%s" % user_data)

--- a/django-cloudlaunch/baselaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/base_vm_app.py
@@ -296,7 +296,8 @@ class BaseVMAppPlugin(AppPlugin):
 
         @type  deployment: ``dict``
         @param deployment: A dictionary describing an instance of the
-                           app deployment.
+                           app deployment, requiring at least the following
+                           keys: ``launch_status``, ``launch_result``.
 
         :rtype: ``str``
         :return: Provider-specific instance ID for the deployment or
@@ -308,7 +309,7 @@ class BaseVMAppPlugin(AppPlugin):
         else:
             return None
 
-    def health_check(self, deployment, provider):
+    def health_check(self, provider, deployment):
         """Check the health of this app."""
         log.debug("Health check for deployment %s", deployment)
         iid = self._get_deployment_iid(deployment)
@@ -321,34 +322,29 @@ class BaseVMAppPlugin(AppPlugin):
         else:
             return {"instance_status": "terminated"}
 
-    def restart(self, deployment, credentials):
+    def restart(self, provider, deployment):
         """Restart the app associated with the supplied deployment."""
         iid = self._get_deployment_iid(deployment)
         if not iid:
             return False
-        log.debug("Restarting deployment %s instance %s",
-                  (deployment.name, iid))
-        provider = domain_model.get_cloud_provider(deployment.target_cloud,
-                                                   credentials)
+        log.debug("Restarting deployment instance %s", iid)
         inst = provider.compute.instances.get(iid)
         if inst:
             return inst.reboot()
         # Instance does not exist so default to False
         return False
 
-    def delete(self, deployment, credentials):
+    def delete(self, provider, deployment):
         """
         Delete resource(s) associated with the supplied deployment.
 
         *Note* that this method will delete resource(s) associated with
-        the deployment - this is un-recoverable action.
+        the deployment - this is an un-recoverable action.
         """
         iid = self._get_deployment_iid(deployment)
         if not iid:
             return False
-        log.debug("Deleting deployment %s instance %s", (deployment.name, iid))
-        provider = domain_model.get_cloud_provider(deployment.target_cloud,
-                                                   credentials)
+        log.debug("Deleting deployment instance %s", iid)
         inst = provider.compute.instances.get(iid)
         if inst:
             return inst.terminate()

--- a/django-cloudlaunch/baselaunch/backend_plugins/cloudman2_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/cloudman2_app.py
@@ -49,11 +49,11 @@ class CloudMan2AppPlugin(BaseVMAppPlugin):
         self.base_app = False
 
     @staticmethod
-    def process_app_config(provider, name, cloud_version_config, app_config):
+    def process_app_config(provider, name, cloud_config, app_config):
         """Format any app-specific configurations."""
         return super(CloudMan2AppPlugin,
                      CloudMan2AppPlugin).process_app_config(
-            provider, name, cloud_version_config, app_config)
+                         provider, name, cloud_config, app_config)
 
     @staticmethod
     def sanitise_app_config(app_config):

--- a/django-cloudlaunch/baselaunch/backend_plugins/cloudman2_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/cloudman2_app.py
@@ -161,7 +161,7 @@ class CloudMan2AppPlugin(BaseVMAppPlugin):
             shutil.rmtree(repo_path)
         return (p_status, out)
 
-    def launch_app(self, provider, task, name, cloud_version_config,
+    def launch_app(self, provider, task, name, cloud_config,
                    app_config, user_data):
         """
         Handle the app launch process.
@@ -179,7 +179,7 @@ class CloudMan2AppPlugin(BaseVMAppPlugin):
         app_config['config_cloudlaunch']['keyPair'] = kp_name
         # Launch an instance and check ssh connectivity
         result = super(CloudMan2AppPlugin, self).launch_app(
-            provider, task, name, cloud_version_config, app_config,
+            provider, task, name, cloud_config, app_config,
             user_data=None)
         inst = provider.compute.instances.get(
             result.get('cloudLaunch', {}).get('instance', {}).get('id'))

--- a/django-cloudlaunch/baselaunch/backend_plugins/cloudman2_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/cloudman2_app.py
@@ -49,12 +49,11 @@ class CloudMan2AppPlugin(BaseVMAppPlugin):
         self.base_app = False
 
     @staticmethod
-    def process_app_config(name, cloud_version_config, credentials,
-                           app_config):
+    def process_app_config(provider, name, cloud_version_config, app_config):
         """Format any app-specific configurations."""
         return super(CloudMan2AppPlugin,
                      CloudMan2AppPlugin).process_app_config(
-            name, cloud_version_config, credentials, app_config)
+            provider, name, cloud_version_config, app_config)
 
     @staticmethod
     def sanitise_app_config(app_config):
@@ -162,7 +161,7 @@ class CloudMan2AppPlugin(BaseVMAppPlugin):
             shutil.rmtree(repo_path)
         return (p_status, out)
 
-    def launch_app(self, task, name, cloud_version_config, credentials,
+    def launch_app(self, provider, task, name, cloud_version_config,
                    app_config, user_data):
         """
         Handle the app launch process.
@@ -180,10 +179,8 @@ class CloudMan2AppPlugin(BaseVMAppPlugin):
         app_config['config_cloudlaunch']['keyPair'] = kp_name
         # Launch an instance and check ssh connectivity
         result = super(CloudMan2AppPlugin, self).launch_app(
-            task, name, cloud_version_config, credentials, app_config,
+            provider, task, name, cloud_version_config, app_config,
             user_data=None)
-        provider = domain_model.get_cloud_provider(cloud_version_config.cloud,
-                                                   credentials)
         inst = provider.compute.instances.get(
             result.get('cloudLaunch', {}).get('instance', {}).get('id'))
         pk = result.get('cloudLaunch', {}).get('keyPair', {}).get('material')

--- a/django-cloudlaunch/baselaunch/backend_plugins/cloudman_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/cloudman_app.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 def get_required_val(data, name, message):
     val = data.get(name)
     if not val:
-        raise ValidationError({ "error" : message })
+        raise ValidationError({"error": message})
     return val
 
 
@@ -21,7 +21,7 @@ class CloudManAppPlugin(BaseVMAppPlugin):
         self.base_app = False
 
     @staticmethod
-    def process_app_config(provider, name, cloud_version_config, app_config):
+    def process_app_config(provider, name, cloud_config, app_config):
         cloudman_config = get_required_val(
             app_config, "config_cloudman", "CloudMan configuration data must be provided.")
         user_data = {}
@@ -61,31 +61,34 @@ class CloudManAppPlugin(BaseVMAppPlugin):
             for key, value in yaml.load(extra_user_data).items():
                 user_data[key] = value
 
-        cloud = cloud_version_config.cloud
-        if hasattr(cloud, 'aws'):
+        if provider.PROVIDER_ID == 'aws':
             user_data['cloud_type'] = 'ec2'
-            user_data['region_name'] = cloud.aws.compute.ec2_region_name
-            user_data['region_endpoint'] = cloud.aws.compute.ec2_region_endpoint
-            user_data['ec2_port'] = cloud.aws.compute.ec2_port
-            user_data['ec2_conn_path'] = cloud.aws.compute.ec2_conn_path
-            user_data['is_secure'] = cloud.aws.compute.ec2_is_secure
-            user_data['s3_host'] = cloud.aws.object_store.s3_host
-            user_data['s3_port'] = cloud.aws.object_store.s3_port
-            user_data['s3_conn_path'] = cloud.aws.object_store.s3_conn_path
+            user_data['region_name'] = provider.region_name
+            user_data['region_endpoint'] = provider.ec2_cfg.get(
+                'endpoint_url') or 'ec2.amazonaws.com'
+            user_data['ec2_port'] = None
+            user_data['ec2_conn_path'] = '/'
+            user_data['is_secure'] = provider.ec2_cfg.get('use_ssl')
+            user_data['s3_host'] = provider.s3_cfg.get(
+                'endpoint_url') or 's3.amazonaws.com'
+            user_data['s3_port'] = None
+            user_data['s3_conn_path'] = '/'
             user_data['access_key'] = provider.session_cfg.get(
                 'aws_access_key_id')
             user_data['secret_key'] = provider.session_cfg.get(
                 'aws_secret_access_key')
-        elif hasattr(cloud, 'openstack'):
+        elif provider.PROVIDER_ID == 'openstack':
             user_data['cloud_type'] = 'openstack'
             ec2_endpoints = provider.security.get_ec2_endpoints()
             if not ec2_endpoints.get('ec2_endpoint'):
-                raise ValidationError({ "error":
-                "This version of CloudMan supports only EC2-compatible clouds. This OpenStack"
-                " cloud provider does not appear to have an ec2 endpoint"})
+                raise ValidationError(
+                    {"error": "This version of CloudMan supports only "
+                              "EC2-compatible clouds. This OpenStack cloud "
+                              "provider does not appear to have an ec2 "
+                              "endpoint."})
             uri_comp = urlparse(ec2_endpoints.get('ec2_endpoint'))
 
-            user_data['region_name'] = cloud.openstack.region_name
+            user_data['region_name'] = provider.region_name
             user_data['region_endpoint'] = uri_comp.hostname
             user_data['ec2_port'] = uri_comp.port
             user_data['ec2_conn_path'] = uri_comp.path
@@ -103,8 +106,9 @@ class CloudManAppPlugin(BaseVMAppPlugin):
             user_data['access_key'] = ec2_creds.access
             user_data['secret_key'] = ec2_creds.secret
         else:
-            raise ValidationError({ "error":
-                "This version of CloudMan supports only EC2-compatible clouds."})
+            raise ValidationError({
+                "error": "This version of CloudMan supports only "
+                         "EC2-compatible clouds."})
 
         return user_data
 
@@ -124,10 +128,11 @@ class CloudManAppPlugin(BaseVMAppPlugin):
             app_config.get('config_cloudlaunch')['customImageID'] = user_data['machine_image_id']
         result = super(CloudManAppPlugin, self).launch_app(
             provider, task, name, cloud_config, app_config, ud)
-        result['cloudLaunch']['applicationURL'] = 'http://{0}/cloud'.format(result['cloudLaunch']['publicIP'])
+        result['cloudLaunch']['applicationURL'] = \
+            'http://{0}/cloud'.format(result['cloudLaunch']['publicIP'])
         task.update_state(
             state='PROGRESSING',
             meta={'action': "Waiting for CloudMan to become ready at %s"
-                  % result['cloudLaunch']['applicationURL']})
+                            % result['cloudLaunch']['applicationURL']})
         self.wait_for_http(result['cloudLaunch']['applicationURL'])
         return result

--- a/django-cloudlaunch/baselaunch/backend_plugins/cloudman_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/cloudman_app.py
@@ -114,7 +114,7 @@ class CloudManAppPlugin(BaseVMAppPlugin):
         app_config['config_cloudman']['clusterPassword'] = '********'
         return app_config
 
-    def launch_app(self, provider, task, name, cloud_version_config,
+    def launch_app(self, provider, task, name, cloud_config,
                    app_config, user_data):
         ud = yaml.dump(user_data, default_flow_style=False, allow_unicode=False)
         # Make sure the placement and image ID (eg from a saved cluster) propagate
@@ -123,7 +123,7 @@ class CloudManAppPlugin(BaseVMAppPlugin):
         if user_data.get('machine_image_id'):
             app_config.get('config_cloudlaunch')['customImageID'] = user_data['machine_image_id']
         result = super(CloudManAppPlugin, self).launch_app(
-            provider, task, name, cloud_version_config, app_config, ud)
+            provider, task, name, cloud_config, app_config, ud)
         result['cloudLaunch']['applicationURL'] = 'http://{0}/cloud'.format(result['cloudLaunch']['publicIP'])
         task.update_state(
             state='PROGRESSING',

--- a/django-cloudlaunch/baselaunch/backend_plugins/docker_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/docker_app.py
@@ -7,7 +7,7 @@ from .base_vm_app import BaseVMAppPlugin
 class DockerAppPlugin(BaseVMAppPlugin):
 
     @staticmethod
-    def process_app_config(provider, name, cloud_version_config, app_config):
+    def process_app_config(provider, name, cloud_config, app_config):
         docker_config = app_config.get('config_docker')
         if not docker_config:
             raise ValidationError("Docker configuration data must be provided.")

--- a/django-cloudlaunch/baselaunch/backend_plugins/docker_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/docker_app.py
@@ -52,9 +52,9 @@ class DockerAppPlugin(BaseVMAppPlugin):
         user_data += " {0}".format(docker_config.get('repo_name'))
         return user_data
 
-    def launch_app(self, provider, task, name, cloud_version_config,
+    def launch_app(self, provider, task, name, cloud_config,
                    app_config, user_data):
         result = super(DockerAppPlugin, self).launch_app(
-            provider, task, name, cloud_version_config, app_config, user_data)
+            provider, task, name, cloud_config, app_config, user_data)
         result['cloudLaunch']['applicationURL'] = 'http://{0}'.format(result['cloudLaunch']['publicIP'])
         return result

--- a/django-cloudlaunch/baselaunch/backend_plugins/docker_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/docker_app.py
@@ -7,7 +7,7 @@ from .base_vm_app import BaseVMAppPlugin
 class DockerAppPlugin(BaseVMAppPlugin):
 
     @staticmethod
-    def process_app_config(name, cloud_version_config, credentials, app_config):
+    def process_app_config(provider, name, cloud_version_config, app_config):
         docker_config = app_config.get('config_docker')
         if not docker_config:
             raise ValidationError("Docker configuration data must be provided.")
@@ -19,7 +19,7 @@ class DockerAppPlugin(BaseVMAppPlugin):
             security_rules = security_group.get('rules', [])
         else:
             security_rules = []
-            security_group = { securityGroup: 'cloudlaunch_docker',
+            security_group = {securityGroup: 'cloudlaunch_docker',
                               description: 'Security group for docker containers',
                               rules: security_rules }
             firewall_config.append(security_group)
@@ -52,7 +52,9 @@ class DockerAppPlugin(BaseVMAppPlugin):
         user_data += " {0}".format(docker_config.get('repo_name'))
         return user_data
 
-    def launch_app(self, task, name, cloud_version_config, credentials, app_config, user_data):
-        result = super(DockerAppPlugin, self).launch_app(task, name, cloud_version_config, credentials, app_config, user_data)
+    def launch_app(self, provider, task, name, cloud_version_config,
+                   app_config, user_data):
+        result = super(DockerAppPlugin, self).launch_app(
+            provider, task, name, cloud_version_config, app_config, user_data)
         result['cloudLaunch']['applicationURL'] = 'http://{0}'.format(result['cloudLaunch']['publicIP'])
         return result

--- a/django-cloudlaunch/baselaunch/backend_plugins/gvl_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/gvl_app.py
@@ -7,11 +7,12 @@ from .base_vm_app import BaseVMAppPlugin
 class GVLAppPlugin(BaseVMAppPlugin):
 
     @staticmethod
-    def process_app_config(name, cloud_version_config, credentials, app_config):
+    def process_app_config(provider, name, cloud_version_config, app_config):
         gvl_config = app_config.get("config_gvl")
         if not gvl_config:
             raise ValidationError("GVL configuration data must be provided.")
-        user_data = CloudManAppPlugin().process_app_config(name, cloud_version_config, credentials, gvl_config)
+        user_data = CloudManAppPlugin().process_app_config(
+            provider, name, cloud_version_config, gvl_config)
         install_list = []
         install_cmdline = gvl_config.get('gvl_cmdline_utilities', False)
         if install_cmdline:
@@ -19,7 +20,7 @@ class GVLAppPlugin(BaseVMAppPlugin):
         install_smrtportal = gvl_config.get('smrt_portal', False)
         if install_smrtportal:
             install_list.append('smrt_portal')
-        user_data['gvl_config'] = { 'install' : install_list }
+        user_data['gvl_config'] = {'install': install_list}
         return user_data
 
     @staticmethod
@@ -29,8 +30,10 @@ class GVLAppPlugin(BaseVMAppPlugin):
         sanitised_config['config_gvl'] = CloudManAppPlugin().sanitise_app_config(gvl_config)
         return sanitised_config
 
-    def launch_app(self, task, name, cloud_version_config, credentials, app_config, user_data):
+    def launch_app(self, provider, task, name, cloud_version_config,
+                   app_config, user_data):
         ud = yaml.dump(user_data, default_flow_style=False, allow_unicode=False)
-        result = super(GVLAppPlugin, self).launch_app(task, name, cloud_version_config, credentials, app_config, ud)
+        result = super(GVLAppPlugin, self).launch_app(
+            provider, task, name, cloud_version_config, app_config, ud)
         result['cloudLaunch']['applicationURL'] = 'http://{0}'.format(result['cloudLaunch']['publicIP'])
         return result

--- a/django-cloudlaunch/baselaunch/backend_plugins/gvl_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/gvl_app.py
@@ -30,10 +30,10 @@ class GVLAppPlugin(BaseVMAppPlugin):
         sanitised_config['config_gvl'] = CloudManAppPlugin().sanitise_app_config(gvl_config)
         return sanitised_config
 
-    def launch_app(self, provider, task, name, cloud_version_config,
+    def launch_app(self, provider, task, name, cloud_config,
                    app_config, user_data):
         ud = yaml.dump(user_data, default_flow_style=False, allow_unicode=False)
         result = super(GVLAppPlugin, self).launch_app(
-            provider, task, name, cloud_version_config, app_config, ud)
+            provider, task, name, cloud_config, app_config, ud)
         result['cloudLaunch']['applicationURL'] = 'http://{0}'.format(result['cloudLaunch']['publicIP'])
         return result

--- a/django-cloudlaunch/baselaunch/backend_plugins/gvl_app.py
+++ b/django-cloudlaunch/baselaunch/backend_plugins/gvl_app.py
@@ -7,12 +7,12 @@ from .base_vm_app import BaseVMAppPlugin
 class GVLAppPlugin(BaseVMAppPlugin):
 
     @staticmethod
-    def process_app_config(provider, name, cloud_version_config, app_config):
+    def process_app_config(provider, name, cloud_config, app_config):
         gvl_config = app_config.get("config_gvl")
         if not gvl_config:
             raise ValidationError("GVL configuration data must be provided.")
         user_data = CloudManAppPlugin().process_app_config(
-            provider, name, cloud_version_config, gvl_config)
+            provider, name, cloud_config, gvl_config)
         install_list = []
         install_cmdline = gvl_config.get('gvl_cmdline_utilities', False)
         if install_cmdline:

--- a/django-cloudlaunch/baselaunch/serializers.py
+++ b/django-cloudlaunch/baselaunch/serializers.py
@@ -712,9 +712,11 @@ class DeploymentTaskSerializer(serializers.ModelSerializer):
             if action == models.ApplicationDeploymentTask.HEALTH_CHECK:
                 async_result = tasks.health_check.delay(dpl, credentials)
             elif action == models.ApplicationDeploymentTask.RESTART:
-                async_result = tasks.restart_appliance.delay(dpl, credentials)
+                async_result = tasks.manage_appliance.delay('restart', dpl,
+                                                            credentials)
             elif action == models.ApplicationDeploymentTask.DELETE:
-                async_result = tasks.delete_appliance.delay(dpl, credentials)
+                async_result = tasks.manage_appliance.delay('delete', dpl,
+                                                            credentials)
             return models.ApplicationDeploymentTask.objects.create(
                 action=action, deployment=dpl, celery_id=async_result.task_id)
         except serializers.ValidationError as ve:

--- a/django-cloudlaunch/baselaunch/serializers.py
+++ b/django-cloudlaunch/baselaunch/serializers.py
@@ -787,17 +787,20 @@ class DeploymentSerializer(serializers.ModelSerializer):
             application_version=version.id, cloud=cloud.slug)
         default_combined_config = cloud_version_config.compute_merged_config()
         request = self.context.get('view').request
+        provider = view_helpers.get_cloud_provider(
+            self.context.get('view'), cloud_id=cloud.slug)
         credentials = view_helpers.get_credentials(cloud, request)
         try:
             handler = util.import_class(version.backend_component_name)()
             app_config = validated_data.get("config_app", {})
 
             merged_config = jsonmerge.merge(default_combined_config, app_config)
-            final_ud_config = handler.process_app_config(name, cloud_version_config,
-                                                         credentials, merged_config)
+            final_ud_config = handler.process_app_config(
+                provider, name, cloud_version_config, merged_config)
             sanitised_app_config = handler.sanitise_app_config(merged_config)
-            async_result = tasks.launch_appliance.delay(name, cloud_version_config,
-                                                        credentials, merged_config, final_ud_config)
+            async_result = tasks.launch_appliance.delay(
+                name, cloud_version_config, credentials, merged_config,
+                final_ud_config)
 
             del validated_data['application']
             del validated_data['config_app']

--- a/django-cloudlaunch/baselaunch/serializers.py
+++ b/django-cloudlaunch/baselaunch/serializers.py
@@ -795,8 +795,9 @@ class DeploymentSerializer(serializers.ModelSerializer):
             app_config = validated_data.get("config_app", {})
 
             merged_config = jsonmerge.merge(default_combined_config, app_config)
+            cloud_config = util.serialize_cloud_config(cloud_version_config)
             final_ud_config = handler.process_app_config(
-                provider, name, cloud_version_config, merged_config)
+                provider, name, cloud_config, merged_config)
             sanitised_app_config = handler.sanitise_app_config(merged_config)
             async_result = tasks.launch_appliance.delay(
                 name, cloud_version_config, credentials, merged_config,

--- a/django-cloudlaunch/baselaunch/tasks.py
+++ b/django-cloudlaunch/baselaunch/tasks.py
@@ -40,25 +40,6 @@ def migrate_launch_task(task_id):
     task.forget()
 
 
-def _serialize_cloud_config(cloud_config):
-    """
-    Serialize the supplied model to a dict.
-
-    A subset of the the model fields is returned as used by current
-    plugins but more fields can be serialized as needed.
-
-    @type  cloud_config: :class:`.models.ApplicationVersionCloudConfig`
-    @param cloud_config: A Django model containing infrastructure
-                         specific configuration to be serialized.
-
-    @rtype: ``dict``
-    @return: A serialized version of the supplied model.
-    """
-    return {'default_instance_type': cloud_config.default_instance_type,
-            'default_launch_config': cloud_config.default_launch_config,
-            'image_id': cloud_config.image.image_id}
-
-
 @shared_task
 def launch_appliance(name, cloud_version_config, credentials, app_config,
                      user_data, task_id=None):
@@ -69,7 +50,7 @@ def launch_appliance(name, cloud_version_config, credentials, app_config,
             cloud_version_config.application_version.backend_component_name)()
         provider = domain_model.get_cloud_provider(cloud_version_config.cloud,
                                                    credentials)
-        cloud_config = _serialize_cloud_config(cloud_version_config)
+        cloud_config = util.serialize_cloud_config(cloud_version_config)
         launch_result = handler.launch_app(provider, launch_appliance, name,
                                            cloud_config, app_config,
                                            user_data)

--- a/django-cloudlaunch/baselaunch/tasks.py
+++ b/django-cloudlaunch/baselaunch/tasks.py
@@ -51,8 +51,8 @@ def launch_appliance(name, cloud_version_config, credentials, app_config,
         provider = domain_model.get_cloud_provider(cloud_version_config.cloud,
                                                    credentials)
         cloud_config = util.serialize_cloud_config(cloud_version_config)
-        launch_result = handler.launch_app(provider, launch_appliance, name,
-                                           cloud_config, app_config,
+        launch_result = handler.launch_app(provider, Task(launch_appliance),
+                                           name, cloud_config, app_config,
                                            user_data)
         # Schedule a task to migrate result one hour from now
         migrate_launch_task.apply_async([launch_appliance.request.id],
@@ -168,3 +168,31 @@ def manage_appliance(self, action, deployment, credentials):
     migrate_task_result.apply_async([self.request.id],
                                     countdown=1)
     return result
+
+
+class Task(object):
+    """
+    An abstraction class for handling task actions.
+
+    Plugins can implement the interface defined here and handle task actions
+    independent CloudLaunch and its task broker.
+    """
+
+    def __init__(self, broker_task):
+        self.task = broker_task
+
+    def update_state(self, task_id=None, state=None, meta=None):
+        """
+        Update task state.
+
+        @type  task_id: ``str``
+        @param task_id: Id of the task to update. Defaults to the id of the
+                        current task.
+
+        @type  state: ``str
+        @param state: New state.
+
+        @type  meta: ``dict``
+        @param meta: State meta-data.
+        """
+        self.task.update_state(state=state, meta=meta)

--- a/django-cloudlaunch/baselaunch/tasks.py
+++ b/django-cloudlaunch/baselaunch/tasks.py
@@ -48,9 +48,11 @@ def launch_appliance(name, cloud_version_config, credentials, app_config,
         LOG.debug("Launching appliance %s", name)
         handler = util.import_class(
             cloud_version_config.application_version.backend_component_name)()
-        launch_result = handler.launch_app(launch_appliance, name,
-                                           cloud_version_config, credentials,
-                                           app_config, user_data)
+        provider = domain_model.get_cloud_provider(cloud_version_config.cloud,
+                                                   credentials)
+        launch_result = handler.launch_app(provider, launch_appliance, name,
+                                           cloud_version_config, app_config,
+                                           user_data)
         # Schedule a task to migrate result one hour from now
         migrate_launch_task.apply_async([launch_appliance.request.id],
                                         countdown=3600)

--- a/django-cloudlaunch/baselaunch/util.py
+++ b/django-cloudlaunch/baselaunch/util.py
@@ -1,16 +1,36 @@
+"""A set of utility functions used by the framework."""
 import operator
 from importlib import import_module
 
+
 def getattrd(obj, name):
-    """
-    Same as ``getattr()``, but allows dot notation lookup.
-    """
+    """Same as ``getattr()``, but allow dot notation lookup."""
     try:
         return operator.attrgetter(name)(obj)
     except AttributeError:
         return None
 
+
 def import_class(name):
     parts = name.rsplit('.', 1)
     cls = getattr(import_module(parts[0]), parts[1])
     return cls
+
+
+def serialize_cloud_config(cloud_config):
+    """
+    Serialize the supplied model to a dict.
+
+    A subset of the the model fields is returned as used by current
+    plugins but more fields can be serialized as needed.
+
+    @type  cloud_config: :class:`.models.ApplicationVersionCloudConfig`
+    @param cloud_config: A Django model containing infrastructure
+                         specific configuration to be serialized.
+
+    @rtype: ``dict``
+    @return: A serialized version of the supplied model.
+    """
+    return {'default_instance_type': cloud_config.default_instance_type,
+            'default_launch_config': cloud_config.default_launch_config,
+            'image_id': cloud_config.image.image_id}


### PR DESCRIPTION
As detailed in https://github.com/galaxyproject/cloudlaunch/issues/89, this eliminates plugin dependencies on components internal to CloudLaunch so they can be developed and (re)used without CloudLaunch.