### PR TITLE
Upgrade to Django 1.11.5

### DIFF
--- a/django-cloudlaunch/baselaunch/serializers.py
+++ b/django-cloudlaunch/baselaunch/serializers.py
@@ -661,6 +661,7 @@ class DeploymentAppSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Application
+        fields = '__all__'
 
 class DeploymentAppVersionSerializer(serializers.ModelSerializer):
     application = DeploymentAppSerializer(read_only=True)
@@ -979,11 +980,13 @@ class LocationSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = models.Location
+        fields = '__all__'
 
 
 class SponsorSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = models.Sponsor
+        fields = '__all__'
 
 
 class PublicServiceSerializer(serializers.HyperlinkedModelSerializer):
@@ -991,3 +994,4 @@ class PublicServiceSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = models.PublicService
+        fields = '__all__'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-Django==1.9
+Django==1.11.5
 celery<=3.1.25
-djangorestframework==3.3.1
+djangorestframework==3.6.4
 wheel==0.24.0
-django-rest-auth==0.8.2
+django-rest-auth==0.9.1
 django-allauth>=0.24.1
 drf-nested-routers>=0.11.1
 git+git://github.com/gvlproject/cloudbridge
 django-model-utils>=2.4
 django-celery>=3.1.17
-django-fernet-fields==0.4 # for encryption of user credentials
+django-fernet-fields==0.5 # for encryption of user credentials
 django-cors-headers>=1.3.1
 django-nested-admin>=3.0.8 # for nested object editing in django admin
 django-smart-selects>=1.2.2 # For dependencies between key fields in django admin


### PR DESCRIPTION
Upgrade for #93

Upgraded Django and django rest framework.

`fields` must be explicitly declared on serializers either with `fields` or `exclude`. `fields = '__all__'` is a shortcut for defining all fields which is the previous default behaviour. Interestingly this was introduced in 3.3.0 of DRF which cloudlaunch already depended on... I've fixed this anyway.

From what I can tell running this project and galaxyproject/cloudlaunch-ui everything seems to work.