### PR TITLE
config_app is optional, only delete if provided

### DIFF
--- a/django-cloudlaunch/cloudlaunch/serializers.py
+++ b/django-cloudlaunch/cloudlaunch/serializers.py
@@ -255,7 +255,8 @@ class DeploymentSerializer(serializers.ModelSerializer):
                 final_ud_config)
 
             del validated_data['application']
-            del validated_data['config_app']
+            if 'config_app' in validated_data:
+                del validated_data['config_app']
             validated_data['owner_id'] = request.user.id
             validated_data['application_config'] = json.dumps(merged_config)
             app_deployment = super(DeploymentSerializer, self).create(validated_data)


### PR DESCRIPTION
With the command line client I was getting this error if not providing config_app:

```
Traceback (most recent call last):
  File "/Users/machrist/SGCI/cloudlaunch/launcher/cloudlaunch/django-cloudlaunch/cloudlaunch/serializers.py", line 261, in create
    del validated_data['config_app']
KeyError: 'config_app'
```

This pull request adds a check to make sure config_app is in validated_data before trying to delete it.
