### PR TITLE
Issue #109: enable coreapi schema

### DIFF
--- a/django-cloudlaunch/cloudlaunch/urls.py
+++ b/django-cloudlaunch/cloudlaunch/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 """
 from django.conf.urls import include
 from django.conf.urls import url
+from rest_framework.schemas import get_schema_view
 
 from . import views
 
@@ -45,6 +46,9 @@ cloud_router.register(r'cloudman', views.CloudManViewSet, base_name='cloudman')
 infrastructure_regex_pattern = r'api/v1/infrastructure/'
 auth_regex_pattern = r'api/v1/auth/'
 public_services_regex_pattern = r'api/v1/public_services/'
+
+schema_view = get_schema_view(title='CloudLaunch API')
+
 urlpatterns = [
     url(r'api/v1/', include(router.urls)),
     url(r'api/v1/', include(deployments_router.urls)),
@@ -63,4 +67,5 @@ urlpatterns = [
     url(r'accounts/', include('allauth.urls')),
     # Public services
     url(public_services_regex_pattern, include('public_appliances.urls')),
+    url(r'api/v1/schema/$', schema_view),
 ]

--- a/django-cloudlaunch/cloudlaunch/views.py
+++ b/django-cloudlaunch/cloudlaunch/views.py
@@ -66,6 +66,8 @@ class CorsProxyView(APIView):
     """
     API endpoint that allows applications to be viewed or edited.
     """
+    exclude_from_schema = True
+
     def get(self, request, format=None):
         url = self.request.query_params.get('url')
         response = requests.get(url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ djangorestframework==3.6.4
 django-rest-auth==0.9.1 # login support for DRF through restful endpoints
 django-allauth>=0.24.1 # pluggable social auth for django login
 drf-nested-routers>=0.11.1 # Provides nested routing for DRF
+coreapi==2.2.3 # Provides REST API schema
 
 # Cloudbridge
 git+git://github.com/gvlproject/cloudbridge


### PR DESCRIPTION
This pull request enables the coreapi schema.  This schema is used by the [cloudlaunch-cli](https://github.com/CloudVE/cloudlaunch-cli) tool to simplify making API calls.