### PR TITLE
Add egg specifier to help pip deal with dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,17 +15,17 @@ django-filter>=1.1.0 # For DRF filtering by querystring
 coreapi==2.2.3 # Provides REST API schema
 
 # Cloudbridge
-git+git://github.com/gvlproject/cloudbridge
-git+git://github.com/CloudVE/djcloudbridge
+git+git://github.com/gvlproject/cloudbridge#egg=cloudbridge
+git+git://github.com/CloudVE/djcloudbridge#egg=djcloudbridge
 
 # Django
 # django-model-utils>=3.1.1 # Provides better inheritance support for django models
-git+git://github.com/jazzband/django-model-utils@3.1.1 # https://github.com/jazzband/django-model-utils/issues/304
+git+git://github.com/jazzband/django-model-utils@3.1.1#egg=django-model-utils # https://github.com/jazzband/django-model-utils/issues/304
 django-fernet-fields==0.5 # for encryption of user credentials
 django-cors-headers>=2.1.0 # Middleware for automatically adding CORS headers to responses
 django-nested-admin>=3.0.21 # for nested object editing in django admin
 # django-smart-selects>=1.5.2 # For dependencies between key fields in django admin
-git+git://github.com/CloudVE/django-smart-selects@django_2_upgrade # Use fork till Django 2 support is merged
+git+git://github.com/CloudVE/django-smart-selects@django_2_upgrade#egg=django-smart-selects # Use fork till Django 2 support is merged
 psycopg2 # postgres database driver
 
 # Production Django


### PR DESCRIPTION
Adding the egg specifier helps pip actually install these custom dependencies from git.  I tested specifically django-model-utils. On a clean virtual environment it would install version 3.0.0 instead of the one specified at the git url. With the egg specifier it installed the 3.1.1 version specified at the git url.