### PR TITLE
Fixes for CloudLaunch tests

### DIFF
--- a/django-cloudlaunch/cloudlaunch/tests.py
+++ b/django-cloudlaunch/cloudlaunch/tests.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -13,7 +13,8 @@ class ApplicationTests(APITestCase):
     APP_DATA = {'name': 'HelloWorldApp',
                 'slug': 'helloworldapp',
                 'description': 'HelloWorldDesc',
-                'info_url': 'http://www.cloudlaunch.org'
+                'info_url': 'http://www.cloudlaunch.org',
+                'status': 'LIVE',
                 }
 
     def _create_application(self, app_data):


### PR DESCRIPTION
Fixes a couple of issues with existing tests:
* `from django.core.urlresolvers import reverse` [no longer is supported in Django 2.0](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0)
* ApplianceViewSet filters to only LIVE appliances. Changed the test appliance to be a LIVE one. 