### PR TITLE
Create REQUIRED_INSTALLED_APPS for Django projects integrating CloudL…

### DIFF
--- a/django-cloudlaunch/cloudlaunchserver/settings.py
+++ b/django-cloudlaunch/cloudlaunchserver/settings.py
@@ -72,13 +72,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Application definition
 
-INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+REQUIRED_INSTALLED_APPS = [
     'django.contrib.sites',
     'nested_admin',
     'smart_selects',
@@ -102,8 +96,17 @@ INSTALLED_APPS = [
     'django_celery_beat',
     'django_countries',
     'django_filters',
-    'raven.contrib.django.raven_compat'
 ]
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'raven.contrib.django.raven_compat'
+] + REQUIRED_INSTALLED_APPS
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
…aunch

Fix for issue #143 

The way this would work for cloudman is in its settings.py you would do
```python
import cloudlaunchserver
INSTALLED_APPS = [
...
] + cloudlaunchserver.settings.REQUIRED_INSTALLED_APPS
```

Maybe there is a better way though. I still want to see how other Django apps handle this.