### PR TITLE
Using name instead of ID for router labeling

### DIFF
--- a/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
@@ -217,7 +217,7 @@ class BaseVMAppPlugin(AppPlugin):
                         log.debug("Returning sn %s" % sn.id)
                         return subnet
             else:
-                router_name = 'cl-router-%s' % subnet.network_id
+                router_name = 'cl-router-%s' % subnet._network.name
                 log.debug("Creating CloudLaunch router %s", router_name)
                 router = provider.networking.routers.create(
                     label=router_name, network=subnet.network_id)


### PR DESCRIPTION
The ID in Azure contains '/' which is not a valid character for labels.
Using name ensures that it is valid in all providers (will map to ID in AWS and OS (alphanumeric with dashes), and to 'Name' in Azure (restrictions in CB conform to label restrictions).
This is a fix for cloudbridge resources, but for a better fix, we could make a helper method to change the label to be conforming while leaving it easily indicative of the resource we are trying to represent.