### PR TITLE
Added support for importing/exporting apps

### DIFF
--- a/django-cloudlaunch/cloudlaunch/management/commands/export_app_data.py
+++ b/django-cloudlaunch/cloudlaunch/management/commands/export_app_data.py
@@ -1,0 +1,27 @@
+import yaml
+from django.core.management.base import BaseCommand
+from cloudlaunch import models as cl_models
+
+import cloudlaunch.management.commands.serializers as mgmt_serializers
+
+
+class Command(BaseCommand):
+    help = 'Exports Application Data in yaml format'
+
+    def add_arguments(self, parser):
+        parser.add_argument('-a', '--applications', nargs='+', type=str,
+                            help='Export only the specified applications')
+
+    def handle(self, *args, **options):
+        return self.export_app_data(applications=options.get('applications'))
+
+    @staticmethod
+    def export_app_data(applications=None):
+        if applications:
+            queryset = cl_models.Application.objects.filter(pk__in=applications)
+        else:
+            queryset = cl_models.Application.objects.all()
+
+        serializer = mgmt_serializers.ApplicationSerializer(queryset, many=True)
+        data = serializer.to_representation(serializer.instance)
+        return yaml.safe_dump(data, default_flow_style=False)

--- a/django-cloudlaunch/cloudlaunch/management/commands/import_app_data.py
+++ b/django-cloudlaunch/cloudlaunch/management/commands/import_app_data.py
@@ -1,0 +1,46 @@
+import argparse
+import requests
+import yaml
+
+from django.core.management.base import BaseCommand
+
+import cloudlaunch.management.commands.serializers as mgmt_serializers
+
+
+class Command(BaseCommand):
+    help = 'Imports Application Data from a given url or file and updates' \
+           ' existing models'
+
+    def file_from_url(url):
+        """
+        Reads a file from a url
+        :return: content of file
+        """
+        try:
+            r = requests.get(url)
+            r.raise_for_status()
+            return r.text
+        except requests.exceptions.RequestException as e:
+            raise argparse.ArgumentTypeError(e)
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('-f', '--file', type=argparse.FileType('r'))
+        group.add_argument('-u', '--url', type=Command.file_from_url)
+
+    def handle(self, *args, **options):
+        if options['file']:
+            content = options['file'].read()
+        else:
+            content = options['url']
+
+        return self.import_app_data(yaml.safe_load(content))
+
+    @staticmethod
+    def import_app_data(yaml_data):
+        serializer = mgmt_serializers.ApplicationSerializer(
+            data=yaml_data, many=True)
+        if serializer.is_valid():
+            serializer.save()
+        else:
+            return serializer.errors

--- a/django-cloudlaunch/cloudlaunch/management/commands/import_app_data.py
+++ b/django-cloudlaunch/cloudlaunch/management/commands/import_app_data.py
@@ -43,4 +43,4 @@ class Command(BaseCommand):
         if serializer.is_valid():
             serializer.save()
         else:
-            return serializer.errors
+            return str(serializer.errors)

--- a/django-cloudlaunch/cloudlaunch/management/commands/serializers.py
+++ b/django-cloudlaunch/cloudlaunch/management/commands/serializers.py
@@ -1,0 +1,102 @@
+from collections import OrderedDict
+import yaml
+
+from rest_framework import serializers
+
+from cloudlaunch import models as cl_models
+
+
+class StoredYAMLField(serializers.JSONField):
+    def __init__(self, *args, **kwargs):
+        super(StoredYAMLField, self).__init__(*args, **kwargs)
+
+    def to_internal_value(self, data):
+        try:
+            return yaml.safe_dump(data, default_flow_style=False)
+        except (TypeError, ValueError):
+            self.fail('invalid')
+        return data
+
+    def to_representation(self, value):
+        try:
+            if value:
+                return yaml.safe_load(value)
+            else:
+                return value
+        except Exception:
+            return value
+
+
+class AppVersionSerializer(serializers.ModelSerializer):
+    default_launch_config = StoredYAMLField(required=False, allow_null=True)
+
+    def get_unique_together_validators(self):
+        """Overriding method to disable unique together checks"""
+        return []
+
+    class Meta:
+        model = cl_models.ApplicationVersion
+        fields = ('version', 'frontend_component_path', 'frontend_component_name',
+                  'backend_component_name', 'default_launch_config')
+
+
+class ApplicationSerializer(serializers.ModelSerializer):
+    default_launch_config = StoredYAMLField(required=False, allow_null=True,
+                                            validators=[])
+    default_version = serializers.CharField(source='default_version.version', default=None)
+    versions = AppVersionSerializer(many=True)
+
+    def create(self, validated_data):
+        return self.update(None, validated_data)
+
+    def update(self, instance, validated_data):
+        slug = validated_data.pop('slug')
+        versions = validated_data.pop('versions')
+        default_version = validated_data.pop('default_version')
+
+        # create the app
+        app, _ = cl_models.Application.objects.update_or_create(
+            slug=slug, defaults=validated_data)
+
+        # create all nested app versions
+        for version in versions:
+            ver_id = version.pop('version')
+            cl_models.ApplicationVersion.objects.update_or_create(
+                application=app, version=ver_id, defaults=version)
+
+        # Now set the default app version
+        if default_version:
+            app.default_version = cl_models.ApplicationVersion.objects.get(
+                application=app, version=default_version['version'])
+            app.save()
+
+        return app
+
+    class Meta:
+        model = cl_models.Application
+        fields = ('slug', 'name', 'status', 'summary', 'maintainer',
+                  'description', 'info_url', 'icon_url', 'display_order',
+                  'default_version', 'default_launch_config', 'versions')
+        extra_kwargs = {
+            'slug': {'validators': []}
+        }
+
+
+# Control YAML serialization
+
+# xref: https://github.com/wimglenn/oyaml/blob/de97b8b2be072a8072e807182ffe3fa11c504fd7/oyaml.py#L10
+def map_representer(dumper, data):
+    return dumper.represent_dict(data.items())
+
+
+def yaml_literal_representer(dumper, data):
+    if len(data) > 50:
+        return dumper.represent_scalar(u'tag:yaml.org,2002:str', data, style='|')
+    else:
+        return dumper.represent_scalar(u'tag:yaml.org,2002:str', data)
+
+
+yaml.add_representer(str, yaml_literal_representer)
+yaml.add_representer(str, yaml_literal_representer, Dumper=yaml.dumper.SafeDumper)
+yaml.add_representer(OrderedDict, map_representer)
+yaml.add_representer(OrderedDict, map_representer, Dumper=yaml.dumper.SafeDumper)

--- a/django-cloudlaunch/cloudlaunch/management/commands/serializers.py
+++ b/django-cloudlaunch/cloudlaunch/management/commands/serializers.py
@@ -43,7 +43,8 @@ class AppVersionSerializer(serializers.ModelSerializer):
 class ApplicationSerializer(serializers.ModelSerializer):
     default_launch_config = StoredYAMLField(required=False, allow_null=True,
                                             validators=[])
-    default_version = serializers.CharField(source='default_version.version', default=None)
+    default_version = serializers.CharField(source='default_version.version', default=None,
+                                            allow_null=True, required=False)
     versions = AppVersionSerializer(many=True)
 
     def create(self, validated_data):
@@ -65,7 +66,7 @@ class ApplicationSerializer(serializers.ModelSerializer):
                 application=app, version=ver_id, defaults=version)
 
         # Now set the default app version
-        if default_version:
+        if default_version and default_version['version']:
             app.default_version = cl_models.ApplicationVersion.objects.get(
                 application=app, version=default_version['version'])
             app.save()

--- a/django-cloudlaunch/cloudlaunch/templates/admin/import_data.html
+++ b/django-cloudlaunch/cloudlaunch/templates/admin/import_data.html
@@ -1,0 +1,18 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<form method="POST">
+  {% csrf_token %}
+  <p>
+  Specify app registry url to import from:
+  </p>
+  <input type="text" name="app_registry_url" value="{{ app_registry_url }}" size="150" />
+  <input type="hidden" name="post" value="yes">
+  {% for row in rows %}
+    <input type="hidden" name="_selected_action" value="{{ row.pk }}" />
+  {% endfor %}
+  <!-- this is necessary to trigger the same action again -->
+  <input type="hidden" name="action" value="import_app_data">
+  <input type="submit" name="apply" value="Update" />
+</form>
+{% endblock %}

--- a/django-cloudlaunch/cloudlaunch/tests/data/apps_new.yaml
+++ b/django-cloudlaunch/cloudlaunch/tests/data/apps_new.yaml
@@ -1,0 +1,399 @@
+- slug: biodocklet
+  name: BioDocklet
+  status: LIVE
+  summary: |-
+    Modified. Abstract the complex data operations of multi-step, bioinformatics pipelines for NGS data analysis.
+  maintainer: thahmina.ali62@myhunter.cuny.edu
+  description: ''
+  info_url: https://www.youtube.com/watch?v=27HLdQVq7_g
+  icon_url: http://i.imgur.com/ViePkQP.jpg
+  display_order: 10000
+  default_version: RNA-Seq - paired
+  default_launch_config: null
+  versions:
+  - version: ChIP-Seq - paired
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-ubuntu-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.base_vm_app.BaseVMAppPlugin
+    default_launch_config:
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '8090'
+            protocol: tcp
+            to: '8090'
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '23'
+          - cidr: 0.0.0.0/0
+            from: '9010'
+            protocol: tcp
+            to: '9010'
+          securityGroup: cloudlaunch-biodocklet
+        instanceType: c3.large
+        instance_user_data: |-
+          #!/bin/bash
+          docker pull bcil/biodocklets:ChIPseq_paired
+          docker pull hello
+  - version: ChIP-Seq - single
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-ubuntu-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.base_vm_app.BaseVMAppPlugin
+    default_launch_config:
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '8090'
+            protocol: tcp
+            to: '8090'
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '22'
+          - cidr: 0.0.0.0/0
+            from: '9010'
+            protocol: tcp
+            to: '9010'
+          securityGroup: cloudlaunch-biodocklet
+        instanceType: c3.large
+        instance_user_data: |-
+          #!/bin/bash
+          docker pull bcil/biodocklets:ChIPseq_single
+  - version: RNA-Seq - paired
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-ubuntu-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.base_vm_app.BaseVMAppPlugin
+    default_launch_config:
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '8090'
+            protocol: tcp
+            to: '8090'
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '22'
+          - cidr: 0.0.0.0/0
+            from: '9010'
+            protocol: tcp
+            to: '9010'
+          securityGroup: cloudlaunch-biodocklet
+        instanceType: c3.large
+        instance_user_data: |-
+          #!/bin/bash
+          docker pull bcil/biodocklets:RNAseq_paired
+- slug: cloudman-20
+  name: CloudMan 2.0
+  status: LIVE
+  summary: An all-new version of CloudMan
+  maintainer: |-
+    enis.afgan@jhu.edu, nuwan.goonasekera@unimelb.ed.au
+  description: |-
+    This appliance will launch a new version of CloudMan - at the moment, this is purely for development purposes and the application has no useful features yet.
+  info_url: |-
+    https://docs.google.com/presentation/d/1h9PVEGdVIHEat_JWTjYZWuU1R23IeGlMW8PZd8yJVuE/edit#slide=id.p
+  icon_url: https://i.imgur.com/4cJu1lC.png
+  display_order: 1050
+  default_version: dev
+  default_launch_config: null
+  versions:
+  - version: dev
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-cm2-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.cloudman2_app.CloudMan2AppPlugin
+    default_launch_config:
+      config_appliance:
+        inventoryTemplate: |-
+          https://gist.githubusercontent.com/afgane/1651c5c1395400ce8ab97a546293d571/raw/98e1da15a2936bcb23dd5fca1ff88259e9c80f3b/i2
+        repository: https://github.com/CloudVE/ansible-cloudman2
+        runner: ansible
+        sshUser: ubuntu
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '22'
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '443'
+            protocol: tcp
+            to: '443'
+          - cidr: 0.0.0.0/0
+            from: '4430'
+            protocol: tcp
+            to: '4430'
+          - cidr: 0.0.0.0/0
+            from: '6443'
+            protocol: tcp
+            to: '6443'
+          - cidr: 0.0.0.0/0
+            from: '2379'
+            protocol: tcp
+            to: '2380'
+          - cidr: 0.0.0.0/0
+            from: '10250'
+            protocol: tcp
+            to: '10250'
+          - cidr: 0.0.0.0/0
+            from: '10251'
+            protocol: tcp
+            to: '10251'
+          - cidr: 0.0.0.0/0
+            from: '10252'
+            protocol: tcp
+            to: '10252'
+          - cidr: 0.0.0.0/0
+            from: '10256'
+            protocol: tcp
+            to: '10256'
+          - cidr: 0.0.0.0/0
+            from: '30000'
+            protocol: tcp
+            to: '32767'
+          - from: '1'
+            protocol: tcp
+            src_group: cloudlaunch-cm2
+            to: '65535'
+          - from: '1'
+            protocol: udp
+            src_group: cloudlaunch-cm2
+            to: '65535'
+          securityGroup: cloudlaunch-cm2
+        vmType: m1.medium
+      config_cloudman2:
+        cm_boot_image: cloudve/cloudman-boot
+        cm_helm_values: |-
+          cluster_type: KUBE_RANCHER
+          rancher_url: "https://{{ rancher_server }}:{{ rancher_port }}"
+          rancher_api_key: "{{ token }}"
+          rancher_cluster_id: "{{ cluster_id }}"
+          rancher_project_id: "{{ project_id }}"
+          cm_initial_cluster_data: "{{ cm_initial_cluster_data|default('') }}"
+
+          helmsman_config:
+            repositories:
+               - name: cloudve
+                 url: https://raw.githubusercontent.com/CloudVE/helm-charts/master/
+               - name: jupyterhub
+                 url: https://jupyterhub.github.io/helm-chart/
+            charts:
+              dashboard:
+                name: stable/kubernetes-dashboard
+                namespace: kube-system
+                values:
+                  rbac:
+                    clusterAdminRole: true
+                  ingress:
+                    enabled: true
+                    annotations:
+                       kubernetes.io/tls-acme: "true"
+                       certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                       nginx.ingress.kubernetes.io/secure-backends: "true"
+                    hosts:
+                       - ~
+          {% if not (rancher_server | ipaddr) %}
+                       - "{{ rancher_server }}"
+                    tls:
+                       - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                         hosts:
+                           - "{{ rancher_server }}"
+          {% endif %}
+                    paths:
+                      - /dashboard
+                      - /dashboard/*
+                  enableInsecureLogin: true
+              cvmfs:
+                name: cloudve/galaxy-cvmfs-csi
+                namespace: cvmfs
+              galaxy:
+                name: cloudve/galaxy
+                namespace: default
+                oidc_client:
+                  client_secret: {{ random_client_secret }}
+                  redirect_uris:
+                    - '{{ '{{' }} include "cloudman.root_url" . {{ '}}{{' }} .Values.helmsman_config.charts.galaxy.values.ingress.path {{ '}}' }}/authnz/custos/callback'
+                tplValues:
+                  configs:
+                    oidc_backends_config.xml: |
+                      <?xml version="1.0"?>
+                      <OIDC>
+                          <provider name="custos">
+                              <url>https://{{ rancher_server }}/auth</url>
+                              <client_id>galaxy-auth</client_id>
+                              <client_secret>{{ '{{' }}.Values.helmsman_config.charts.galaxy.oidc_client.client_secret {{ '}}' }}</client_secret>
+                              <redirect_uri>https://{{ rancher_server }}{{ '{{' }} .Values.helmsman_config.charts.galaxy.values.ingress.path {{ '}}' }}/authnz/custos/callback</redirect_uri>
+                              <realm>master</realm>
+                          </provider>
+                      </OIDC>
+                values:
+                  configs:
+                    galaxy.yml: |
+                      uwsgi:
+                        virtualenv: /galaxy/server/.venv
+                        processes: 1
+                        http: 0.0.0.0:8080
+                        static-map: /static/style=/galaxy/server/static/style/blue
+                        static-map: /static=/galaxy/server/static
+                        static-map: /favicon.ico=/galaxy/server/static/favicon.ico
+                        pythonpath: /galaxy/server/lib
+                        thunder-lock: true
+                        manage-script-name: true
+                        mount: {{ '{{' }}.Values.ingress.path{{ '}}' }}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
+                        buffer-size: 16384
+                        offload-threads: 2
+                        threads: 4
+                        die-on-term: true
+                        master: true
+                        hook-master-start: unix_signal:2 gracefully_kill_them_all
+                        enable-threads: true
+                        py-call-osafterfork: true
+                      galaxy:
+                        database_connection: 'postgresql://{{ '{{' }}.Values.postgresql.galaxyDatabaseUser{{ '}}' }}:{{ '{{' }}.Values.postgresql.galaxyDatabasePassword{{ '}}' }}@{{ '{{' }} template "galaxy-postgresql.fullname" . {{ '}}' }}/galaxy'
+                        integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
+                        sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
+                        tool_config_file: "/galaxy/server/config/tool_conf.xml,{{ '{{' }}.Values.cvmfs.main.mountPath {{ '}}' }}/config/shed_tool_conf.xml"
+                        shed_tool_config_file: "{{ '{{' }}.Values.persistence.mountPath{{ '}}' }}/config/editable_shed_tool_conf.xml"
+                        tool_data_table_config_path: "{{ '{{' }}.Values.cvmfs.main.mountPath {{ '}}' }}/config/shed_tool_data_table_conf.xml,{{ '{{' }}.Values.cvmfs.data.mountPath{{ '}}' }}/managed/location/tool_data_table_conf.xml,{{ '{{' }}.Values.cvmfs.data.mountPath{{ '}}' }}/byhand/location/tool_data_table_conf.xml"
+                        tool_dependency_dir: "{{ '{{' }}.Values.persistence.mountPath{{ '}}' }}/deps"
+                        builds_file_path: "{{ '{{' }}.Values.cvmfs.data.mountPath{{ '}}' }}/managed/location/builds.txt"
+                        datatypes_config_file: "{{ '{{' }}.Values.cvmfs.main.mountPath {{ '}}' }}/config/datatypes_conf.xml"
+                        containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
+                        workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"
+                        build_sites_config_file: "/galaxy/server/config/build_sites.yml"
+                        enable_oidc: true
+                        oidc_config_file: /galaxy/server/config/oidc_config.xml
+                        oidc_backends_config_file: /galaxy/server/config/oidc_backends_config.xml
+                    oidc_config.xml: |
+                      <?xml version="1.0"?>
+                      <OIDC>
+                          <Setter Property="VERIFY_SSL" Value="False" Type="bool"/>
+                          <Setter Property="REQUESTS_TIMEOUT" Value="3600" Type="float"/>
+                          <Setter Property="ID_TOKEN_MAX_AGE" Value="3600" Type="float"/>
+                      </OIDC>
+                  persistence:
+                    storageClass: nfs-provisioner
+                    size: 95Gi
+                  postgresql:
+                    persistence:
+                      storageClass: ebs-provisioner
+                  ingress:
+                    enabled: true
+                    annotations:
+                       kubernetes.io/tls-acme: "true"
+                       certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                       nginx.ingress.kubernetes.io/secure-backends: "true"
+                    hosts:
+                       - ~
+          {% if not (rancher_server | ipaddr) %}
+                       - "{{ rancher_server }}"
+                    tls:
+                       - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                         hosts:
+                           - "{{ rancher_server }}"
+          {% endif %}
+                    path: /default/galaxy
+
+          cloudlaunch:
+             cloudlaunchserver:
+                admin_password: "{{ rancher_password }}"
+                postgresql:
+                   persistence:
+                      storageClass: "ebs-provisioner"
+                ingress:
+                   annotations:
+                      kubernetes.io/tls-acme: "true"
+                      certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                      nginx.ingress.kubernetes.io/secure-backends: "true"
+                   hosts:
+                      - ~
+          {% if not (rancher_server | ipaddr) %}
+                      - "{{ rancher_server }}"
+                   tls:
+                      - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                        hosts:
+                          - "{{ rancher_server }}"
+          {% endif %}
+             ingress:
+                annotations:
+                   kubernetes.io/tls-acme: "true"
+                   certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                   nginx.ingress.kubernetes.io/secure-backends: "true"
+                hosts:
+                   - ~
+          {% if not (rancher_server | ipaddr) %}
+                   - "{{ rancher_server }}"
+                tls:
+                   - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                     hosts:
+                       - "{{ rancher_server }}"
+          {% endif %}
+          prometheus:
+             persistence:
+                storageClass: "nfs-provisioner"
+             grafana:
+                domain: "{{ rancher_server }}"
+                ingress:
+                   annotations:
+                      kubernetes.io/tls-acme: "true"
+                      certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                      nginx.ingress.kubernetes.io/secure-backends: "true"
+                   hosts:
+                      - ~
+          {% if not (rancher_server | ipaddr) %}
+                      - "{{ rancher_server }}"
+                   tls:
+                      - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                        hosts:
+                          - "{{ rancher_server }}"
+          {% endif %}
+          keycloak:
+             keycloak:
+                 password: "{{ rancher_password }}"
+                 ingress:
+                   enabled: true
+                   path: /auth
+                   annotations:
+                      kubernetes.io/tls-acme: "true"
+                      certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                      nginx.ingress.kubernetes.io/secure-backends: "true"
+                   hosts:
+                      - ~
+          {% if not (rancher_server | ipaddr) %}
+                      - "{{ rancher_server }}"
+                   tls:
+                      - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                        hosts:
+                          - "{{ rancher_server }}"
+          {% endif %}
+          global:
+             domain: "{{ rancher_server }}"

--- a/django-cloudlaunch/cloudlaunch/tests/data/apps_update.yaml
+++ b/django-cloudlaunch/cloudlaunch/tests/data/apps_update.yaml
@@ -1,0 +1,400 @@
+- slug: biodocklet
+  name: BioDocklet
+  status: LIVE
+  summary: |-
+    Modified. Abstract the complex data operations of multi-step, bioinformatics pipelines for NGS data analysis.
+  maintainer: thahmina.ali62@myhunter.cuny.edu
+  description: ''
+  info_url: https://www.youtube.com/watch?v=27HLdQVq7_g
+  icon_url: http://i.imgur.com/ViePkQP.jpg
+  display_order: 10000
+  default_version: RNA-Seq - paired
+  default_launch_config: null
+  versions:
+  - version: ChIP-Seq - paired
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-ubuntu-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.base_vm_app.BaseVMAppPlugin
+    default_launch_config:
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '8090'
+            protocol: tcp
+            to: '8090'
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '23'
+          - cidr: 0.0.0.0/0
+            from: '9010'
+            protocol: tcp
+            to: '9010'
+          securityGroup: cloudlaunch-biodocklet
+        instanceType: c3.large
+        instance_user_data: |-
+          #!/bin/bash
+          docker pull bcil/biodocklets:ChIPseq_paired
+          docker pull hello
+  - version: ChIP-Seq - single
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-ubuntu-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.base_vm_app.BaseVMAppPlugin
+    default_launch_config:
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '8090'
+            protocol: tcp
+            to: '8090'
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '22'
+          - cidr: 0.0.0.0/0
+            from: '9010'
+            protocol: tcp
+            to: '9010'
+          securityGroup: cloudlaunch-biodocklet
+        instanceType: c3.large
+        instance_user_data: |-
+          #!/bin/bash
+          docker pull bcil/biodocklets:ChIPseq_single
+  - version: RNA-Seq - paired
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-ubuntu-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.base_vm_app.BaseVMAppPlugin
+    default_launch_config:
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '8090'
+            protocol: tcp
+            to: '8090'
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '22'
+          - cidr: 0.0.0.0/0
+            from: '9010'
+            protocol: tcp
+            to: '9010'
+          securityGroup: cloudlaunch-biodocklet
+        instanceType: c3.large
+        instance_user_data: |-
+          #!/bin/bash
+          docker pull bcil/biodocklets:RNAseq_paired
+- slug: cloudman-20
+  name: CloudMan 2.0 Updated
+  status: LIVE
+  summary: A different summary
+  maintainer: |-
+    enis.afgan@jhu.edu, nuwan.goonasekera@unimelb.ed.au
+  description: |-
+    This appliance will launch a new version of CloudMan - at the moment, this is purely for development purposes and the application has no useful features yet.
+  info_url: |-
+    https://docs.google.com/presentation/d/1h9PVEGdVIHEat_JWTjYZWuU1R23IeGlMW8PZd8yJVuE/edit#slide=id.p
+  icon_url: https://i.imgur.com/4cJu1lC.png
+  display_order: 1050
+  default_version: dev
+  default_launch_config: null
+  versions:
+  - version: dev
+    frontend_component_path: |-
+      app/marketplace/plugins/plugins.module#PluginsModule
+    frontend_component_name: clui-cm2-config
+    backend_component_name: |-
+      cloudlaunch.backend_plugins.cloudman2_app.CloudMan2AppPlugin
+    default_launch_config:
+      config_appliance:
+        inventoryTemplate: |-
+          https://gist.githubusercontent.com/afgane/1651c5c1395400ce8ab97a546293d571/raw/98e1da15a2936bcb23dd5fca1ff88259e9c80f3b/i2
+        repository: https://github.com/CloudVE/ansible-cloudman2
+        runner: ansible
+        sshUser: ubuntu
+      config_cloudlaunch:
+        firewall:
+        - rules:
+          - cidr: 0.0.0.0/0
+            from: '22'
+            protocol: tcp
+            to: '22'
+          - cidr: 0.0.0.0/0
+            from: '80'
+            protocol: tcp
+            to: '80'
+          - cidr: 0.0.0.0/0
+            from: '443'
+            protocol: tcp
+            to: '443'
+          - cidr: 0.0.0.0/0
+            from: '4430'
+            protocol: tcp
+            to: '4430'
+          - cidr: 0.0.0.0/0
+            from: '6443'
+            protocol: tcp
+            to: '6443'
+          - cidr: 0.0.0.0/0
+            from: '2379'
+            protocol: tcp
+            to: '2380'
+          - cidr: 0.0.0.0/0
+            from: '10250'
+            protocol: tcp
+            to: '10250'
+          - cidr: 0.0.0.0/0
+            from: '10251'
+            protocol: tcp
+            to: '10251'
+          - cidr: 0.0.0.0/0
+            from: '10252'
+            protocol: tcp
+            to: '10252'
+          - cidr: 0.0.0.0/0
+            from: '10256'
+            protocol: tcp
+            to: '10256'
+          - cidr: 0.0.0.0/0
+            from: '30000'
+            protocol: tcp
+            to: '32767'
+          - from: '1'
+            protocol: tcp
+            src_group: cloudlaunch-cm2
+            to: '65535'
+          - from: '1'
+            protocol: udp
+            src_group: cloudlaunch-cm2
+            to: '65535'
+          securityGroup: cloudlaunch-cm2
+        vmType: m1.medium
+      config_cloudman2:
+        cm_boot_image: cloudve/cloudman-boot
+        cm_helm_values: |-
+          cluster_type: KUBE_RANCHER
+          rancher_url: "https://{{ rancher_server }}:{{ rancher_port }}"
+          rancher_api_key: "{{ token }}"
+          rancher_cluster_id: "{{ cluster_id }}"
+          rancher_project_id: "{{ project_id }}"
+          cm_initial_cluster_data: "{{ cm_initial_cluster_data|default('') }}"
+
+          helmsman_config:
+            repositories:
+               - name: cloudve
+                 url: https://raw.githubusercontent.com/CloudVE/helm-charts/master/
+               - name: jupyterhub
+                 url: https://jupyterhub.github.io/helm-chart/
+            charts:
+              dashboard:
+                name: stable/kubernetes-dashboard
+                namespace: kube-system
+                values:
+                  rbac:
+                    clusterAdminRole: true
+                  ingress:
+                    enabled: true
+                    annotations:
+                       kubernetes.io/tls-acme: "true"
+                       certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                       nginx.ingress.kubernetes.io/secure-backends: "true"
+                    hosts:
+                       - ~
+          {% if not (rancher_server | ipaddr) %}
+                       - "{{ rancher_server }}"
+                    tls:
+                       - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                         hosts:
+                           - "{{ rancher_server }}"
+          {% endif %}
+                    paths:
+                      - /dashboard
+                      - /dashboard/*
+                  enableInsecureLogin: true
+              cvmfs:
+                name: cloudve/galaxy-cvmfs-csi
+                namespace: cvmfs
+              galaxy:
+                name: cloudve/galaxy
+                namespace: default
+                oidc_client:
+                  client_secret: {{ random_client_secret }}
+                  redirect_uris:
+                    - '{{ '{{' }} include "cloudman.root_url" . {{ '}}{{' }} .Values.helmsman_config.charts.galaxy.values.ingress.path {{ '}}' }}/authnz/custos/callback'
+                tplValues:
+                  configs:
+                    oidc_backends_config.xml: |
+                      <?xml version="1.0"?>
+                      <OIDC>
+                          <provider name="custos">
+                              <url>https://{{ rancher_server }}/auth</url>
+                              <client_id>galaxy-auth</client_id>
+                              <client_secret>{{ '{{' }}.Values.helmsman_config.charts.galaxy.oidc_client.client_secret {{ '}}' }}</client_secret>
+                              <redirect_uri>https://{{ rancher_server }}{{ '{{' }} .Values.helmsman_config.charts.galaxy.values.ingress.path {{ '}}' }}/authnz/custos/callback</redirect_uri>
+                              <realm>master</realm>
+                          </provider>
+                      </OIDC>
+                values:
+                  configs:
+                    galaxy.yml: |
+                      uwsgi:
+                        virtualenv: /galaxy/server/.venv
+                        processes: 1
+                        http: 0.0.0.0:8080
+                        static-map: /static/style=/galaxy/server/static/style/blue
+                        static-map: /static=/galaxy/server/static
+                        static-map: /favicon.ico=/galaxy/server/static/favicon.ico
+                        pythonpath: /galaxy/server/lib
+                        thunder-lock: true
+                        manage-script-name: true
+                        mount: {{ '{{' }}.Values.ingress.path{{ '}}' }}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
+                        buffer-size: 16384
+                        offload-threads: 2
+                        threads: 4
+                        die-on-term: true
+                        master: true
+                        hook-master-start: unix_signal:2 gracefully_kill_them_all
+                        enable-threads: true
+                        py-call-osafterfork: true
+                      galaxy:
+                        database_connection: 'postgresql://{{ '{{' }}.Values.postgresql.galaxyDatabaseUser{{ '}}' }}:{{ '{{' }}.Values.postgresql.galaxyDatabasePassword{{ '}}' }}@{{ '{{' }} template "galaxy-postgresql.fullname" . {{ '}}' }}/galaxy'
+                        integrated_tool_panel_config: "/galaxy/server/config/mutable/integrated_tool_panel.xml"
+                        sanitize_whitelist_file: "/galaxy/server/config/mutable/sanitize_whitelist.txt"
+                        tool_config_file: "/galaxy/server/config/tool_conf.xml,{{ '{{' }}.Values.cvmfs.main.mountPath {{ '}}' }}/config/shed_tool_conf.xml"
+                        shed_tool_config_file: "{{ '{{' }}.Values.persistence.mountPath{{ '}}' }}/config/editable_shed_tool_conf.xml"
+                        tool_data_table_config_path: "{{ '{{' }}.Values.cvmfs.main.mountPath {{ '}}' }}/config/shed_tool_data_table_conf.xml,{{ '{{' }}.Values.cvmfs.data.mountPath{{ '}}' }}/managed/location/tool_data_table_conf.xml,{{ '{{' }}.Values.cvmfs.data.mountPath{{ '}}' }}/byhand/location/tool_data_table_conf.xml"
+                        tool_dependency_dir: "{{ '{{' }}.Values.persistence.mountPath{{ '}}' }}/deps"
+                        builds_file_path: "{{ '{{' }}.Values.cvmfs.data.mountPath{{ '}}' }}/managed/location/builds.txt"
+                        datatypes_config_file: "{{ '{{' }}.Values.cvmfs.main.mountPath {{ '}}' }}/config/datatypes_conf.xml"
+                        containers_resolvers_config_file: "/galaxy/server/config/container_resolvers_conf.xml"
+                        workflow_schedulers_config_file: "/galaxy/server/config/workflow_schedulers_conf.xml"
+                        build_sites_config_file: "/galaxy/server/config/build_sites.yml"
+                        enable_oidc: true
+                        oidc_config_file: /galaxy/server/config/oidc_config.xml
+                        oidc_backends_config_file: /galaxy/server/config/oidc_backends_config.xml
+                    oidc_config.xml: |
+                      <?xml version="1.0"?>
+                      <OIDC>
+                          <Setter Property="VERIFY_SSL" Value="False" Type="bool"/>
+                          <Setter Property="REQUESTS_TIMEOUT" Value="3600" Type="float"/>
+                          <Setter Property="ID_TOKEN_MAX_AGE" Value="3600" Type="float"/>
+                      </OIDC>
+                  persistence:
+                    storageClass: nfs-provisioner
+                    size: 95Gi
+                  postgresql:
+                    persistence:
+                      storageClass: ebs-provisioner
+                  ingress:
+                    enabled: true
+                    annotations:
+                       kubernetes.io/tls-acme: "true"
+                       certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                       nginx.ingress.kubernetes.io/secure-backends: "true"
+                    hosts:
+                       - ~
+          {% if not (rancher_server | ipaddr) %}
+                       - "{{ rancher_server }}"
+                    tls:
+                       - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                         hosts:
+                           - "{{ rancher_server }}"
+          {% endif %}
+                    path: /default/galaxy
+
+          cloudlaunch:
+             cloudlaunchserver:
+                admin_password: "{{ rancher_password }}"
+                postgresql:
+                   persistence:
+                      storageClass: "ebs-provisioner"
+                ingress:
+                   annotations:
+                      kubernetes.io/tls-acme: "true"
+                      certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                      nginx.ingress.kubernetes.io/secure-backends: "true"
+                   hosts:
+                      - ~
+          {% if not (rancher_server | ipaddr) %}
+                      - "{{ rancher_server }}"
+                   tls:
+                      - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                        hosts:
+                          - "{{ rancher_server }}"
+          {% endif %}
+             ingress:
+                annotations:
+                   kubernetes.io/tls-acme: "true"
+                   certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                   nginx.ingress.kubernetes.io/secure-backends: "true"
+                hosts:
+                   - ~
+          {% if not (rancher_server | ipaddr) %}
+                   - "{{ rancher_server }}"
+                tls:
+                   - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                     hosts:
+                       - "{{ rancher_server }}"
+          {% endif %}
+          prometheus:
+             persistence:
+                storageClass: "nfs-provisioner"
+             grafana:
+                domain: "{{ rancher_server }}"
+                ingress:
+                   annotations:
+                      kubernetes.io/tls-acme: "true"
+                      certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                      nginx.ingress.kubernetes.io/secure-backends: "true"
+                   hosts:
+                      - ~
+          {% if not (rancher_server | ipaddr) %}
+                      - "{{ rancher_server }}"
+                   tls:
+                      - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                        hosts:
+                          - "{{ rancher_server }}"
+          {% endif %}
+          keycloak:
+             keycloak:
+                 password: "{{ rancher_password }}"
+                 ingress:
+                   enabled: true
+                   path: /auth
+                   annotations:
+                      kubernetes.io/tls-acme: "true"
+                      certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+                      nginx.ingress.kubernetes.io/secure-backends: "true"
+                   hosts:
+                      - ~
+          {% if not (rancher_server | ipaddr) %}
+                      - "{{ rancher_server }}"
+                   tls:
+                      - secretName: "{{ rancher_server | replace('.', '-') }}-key"
+                        hosts:
+                          - "{{ rancher_server }}"
+          {% endif %}
+          global:
+             some_new_text
+             domain: "{{ rancher_server }}"

--- a/django-cloudlaunch/cloudlaunch/tests/test_api.py
+++ b/django-cloudlaunch/cloudlaunch/tests/test_api.py
@@ -12,13 +12,14 @@ from djcloudbridge import models as cb_models
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from .models import (Application,
-                     ApplicationDeployment,
-                     ApplicationVersion,
-                     ApplicationVersionCloudConfig,
-                     ApplicationDeploymentTask,
-                     CloudDeploymentTarget,
-                     Image)
+from cloudlaunch.models import (
+    Application,
+    ApplicationDeployment,
+    ApplicationVersion,
+    ApplicationVersionCloudConfig,
+    ApplicationDeploymentTask,
+    CloudDeploymentTarget,
+    Image)
 
 
 @contextmanager

--- a/django-cloudlaunch/cloudlaunch/tests/test_mgmt_commands.py
+++ b/django-cloudlaunch/cloudlaunch/tests/test_mgmt_commands.py
@@ -1,0 +1,54 @@
+from io import StringIO
+import os
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from cloudlaunch import models as cl_models
+
+
+TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+
+
+class ImportAppCommandTestCase(TestCase):
+
+    APP_DATA_PATH_NEW = os.path.join(
+        TEST_DATA_PATH, 'apps_new.yaml')
+    APP_DATA_PATH_UPDATED = os.path.join(
+        TEST_DATA_PATH, 'apps_update.yaml')
+
+    def test_import_app_data_no_args(self):
+        with self.assertRaisesRegex(CommandError,
+                                    "-f/--file -u/--url is required"):
+            call_command('import_app_data')
+
+    def test_import_new_app_data_from_file(self):
+        call_command('import_app_data', '-f', self.APP_DATA_PATH_NEW)
+        app_obj = cl_models.Application.objects.get(
+            slug='biodocklet')
+        self.assertEquals(app_obj.name, 'BioDocklet')
+        self.assertIn('bcil/biodocklets:RNAseq_paired',
+                      app_obj.default_version.default_launch_config)
+
+    def test_import_existing_app_data_from_file(self):
+        call_command('import_app_data', '-f', self.APP_DATA_PATH_NEW)
+        call_command('import_app_data', '-f', self.APP_DATA_PATH_UPDATED)
+        app_obj = cl_models.Application.objects.get(
+            slug='cloudman-20')
+        self.assertEquals(app_obj.name, 'CloudMan 2.0 Updated')
+        self.assertEquals(app_obj.summary, 'A different summary')
+        self.assertIn('some_new_text',
+                      app_obj.default_version.default_launch_config)
+
+    def test_export_matches_import(self):
+        call_command('import_app_data', '-f', self.APP_DATA_PATH_NEW)
+        out = StringIO()
+        call_command('export_app_data', stdout=out)
+        with open(self.APP_DATA_PATH_NEW) as f:
+            self.assertEquals(f.read(), out.getvalue())
+
+    def test_export_subset(self):
+        call_command('import_app_data', '-f', self.APP_DATA_PATH_NEW)
+        out = StringIO()
+        call_command('export_app_data', '-a', 'biodocklet', stdout=out)
+        self.assertNotIn('cloudman-20', out.getvalue())

--- a/django-cloudlaunch/cloudlaunch/tests/test_mgmt_commands.py
+++ b/django-cloudlaunch/cloudlaunch/tests/test_mgmt_commands.py
@@ -1,5 +1,6 @@
 from io import StringIO
 import os
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
@@ -16,8 +17,7 @@ class ImportAppCommandTestCase(TestCase):
         TEST_DATA_PATH, 'apps_new.yaml')
     APP_DATA_PATH_UPDATED = os.path.join(
         TEST_DATA_PATH, 'apps_update.yaml')
-    APP_DATA_PATH_URL = 'https://raw.githubusercontent.com/CloudVE/' \
-                        'cloudlaunch-registry/master/app-registry.yaml'
+    APP_DATA_PATH_URL = settings.CLOUDLAUNCH_APP_REGISTRY_URL
 
     def test_import_app_data_no_args(self):
         with self.assertRaisesRegex(CommandError,

--- a/django-cloudlaunch/cloudlaunch/tests/test_mgmt_commands.py
+++ b/django-cloudlaunch/cloudlaunch/tests/test_mgmt_commands.py
@@ -16,6 +16,8 @@ class ImportAppCommandTestCase(TestCase):
         TEST_DATA_PATH, 'apps_new.yaml')
     APP_DATA_PATH_UPDATED = os.path.join(
         TEST_DATA_PATH, 'apps_update.yaml')
+    APP_DATA_PATH_URL = 'https://raw.githubusercontent.com/CloudVE/' \
+                        'cloudlaunch-registry/master/app-registry.yaml'
 
     def test_import_app_data_no_args(self):
         with self.assertRaisesRegex(CommandError,
@@ -38,6 +40,14 @@ class ImportAppCommandTestCase(TestCase):
         self.assertEquals(app_obj.name, 'CloudMan 2.0 Updated')
         self.assertEquals(app_obj.summary, 'A different summary')
         self.assertIn('some_new_text',
+                      app_obj.default_version.default_launch_config)
+
+    def test_import_new_app_data_from_url(self):
+        call_command('import_app_data', '--url', self.APP_DATA_PATH_URL)
+        app_obj = cl_models.Application.objects.get(
+            slug='pulsar-standalone')
+        self.assertEquals(app_obj.name, 'Galaxy Cloud Bursting')
+        self.assertIn('config_cloudlaunch',
                       app_obj.default_version.default_launch_config)
 
     def test_export_matches_import(self):

--- a/django-cloudlaunch/cloudlaunchserver/settings.py
+++ b/django-cloudlaunch/cloudlaunchserver/settings.py
@@ -297,7 +297,7 @@ LOGGING = {
 }
 
 # CloudLaunch specific settings
-CLOUDLAUNCH_APP_REGISTRY_URL = 'https://raw.githubusercontent.com/CloudVE/' \
+CLOUDLAUNCH_APP_REGISTRY_URL = 'https://raw.githubusercontent.com/galaxyproject/' \
                                'cloudlaunch-registry/master/app-registry.yaml'
 
 

--- a/django-cloudlaunch/cloudlaunchserver/settings.py
+++ b/django-cloudlaunch/cloudlaunchserver/settings.py
@@ -296,6 +296,11 @@ LOGGING = {
     }
 }
 
+# CloudLaunch specific settings
+CLOUDLAUNCH_APP_REGISTRY_URL = 'https://raw.githubusercontent.com/CloudVE/' \
+                               'cloudlaunch-registry/master/app-registry.yaml'
+
+
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 # Allow settings to be overridden in a cloudlaunch/settings_local.py


### PR DESCRIPTION
This allows app data to be imported from a file or url with the goal of supporting a remote app registry for cloudlaunch.
Todo:

Remaining:
* ~Add Django admin action to be able to do this easier from within Django admin.~
* ~Make default_cloud_config read-only.~
* Should we move app registry to galaxyproject/cloudlaunch-app-registry