### PR TITLE
Support router attached to different net's sn

### DIFF
--- a/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
@@ -227,6 +227,7 @@ class BaseVMAppPlugin(AppPlugin):
                 provider, net_id, placement)
         # Make sure the subnet has Internet connectivity
         try:
+            # This will allow to re-use a router when subnets from multiple networks are attached to it
             if provider.PROVIDER_ID == 'openstack':
                 found_routers = [router for router in provider.networking.routers
                                  if subnet.network_id in [port.network_id for port in

--- a/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
@@ -228,7 +228,8 @@ class BaseVMAppPlugin(AppPlugin):
         # Make sure the subnet has Internet connectivity
         try:
             found_routers = [router for router in provider.networking.routers
-                             if router.network_id == subnet.network_id]
+                             subnet.network_id in [port.network_id for port in
+                                                   router._provider.os_conn.list_ports(filters={'device_id': self.id})]]
             # Check if the subnet's network is connected to a router
             router = None
             for r in found_routers:

--- a/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
@@ -228,6 +228,7 @@ class BaseVMAppPlugin(AppPlugin):
         # Make sure the subnet has Internet connectivity
         try:
             # This will allow to re-use a router when subnets from multiple networks are attached to it
+            # xref: https://github.com/galaxyproject/cloudlaunch/pull/261
             if provider.PROVIDER_ID == 'openstack':
                 found_routers = [router for router in provider.networking.routers
                                  if subnet.network_id in [port.network_id for port in

--- a/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
@@ -227,9 +227,13 @@ class BaseVMAppPlugin(AppPlugin):
                 provider, net_id, placement)
         # Make sure the subnet has Internet connectivity
         try:
-            found_routers = [router for router in provider.networking.routers
-                             if subnet.network_id in [port.network_id for port in
-                                                   router._provider.os_conn.list_ports(filters={'device_id': self.id})]]
+            if provider.PROVIDER_ID == 'openstack':
+                found_routers = [router for router in provider.networking.routers
+                                 if subnet.network_id in [port.network_id for port in
+                                                          provider.os_conn.list_ports(filters={'device_id': self.id})]]
+            else:
+                found_routers = [router for router in provider.networking.routers
+                                 if router.network_id == subnet.network_id]
             # Check if the subnet's network is connected to a router
             router = None
             for r in found_routers:

--- a/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
+++ b/django-cloudlaunch/cloudlaunch/backend_plugins/base_vm_app.py
@@ -228,7 +228,7 @@ class BaseVMAppPlugin(AppPlugin):
         # Make sure the subnet has Internet connectivity
         try:
             found_routers = [router for router in provider.networking.routers
-                             subnet.network_id in [port.network_id for port in
+                             if subnet.network_id in [port.network_id for port in
                                                    router._provider.os_conn.list_ports(filters={'device_id': self.id})]]
             # Check if the subnet's network is connected to a router
             router = None


### PR DESCRIPTION
This is particularly relevant for JS2 where the router quota was changed to 1. This will allow to re-use a router when subnets from multiple networks are attached to it.